### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto_pirc_upgrade.yml
+++ b/.github/workflows/auto_pirc_upgrade.yml
@@ -1,4 +1,6 @@
 name: PiRC Auto-Upgrade & Build
+permissions:
+  contents: write
 on:
   push:
     branches: [ main, pirc_final_update.py ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ze0ro99/PiRC/security/code-scanning/1](https://github.com/Ze0ro99/PiRC/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block so the `GITHUB_TOKEN` has only the scopes the workflow actually needs. This can be done at the workflow root (applies to all jobs) or per-job. Here there is a single job that performs Git commits and pushes, so we must allow `contents: write`. No other special scopes (like `pull-requests`, `issues`, etc.) are obviously required.

The safest change without altering existing functionality is to add a workflow-level `permissions:` block right after the `name:` (or right after `on:`) specifying `contents: write`. This keeps the ability to push commits while restricting the token to repository contents only. Concretely, in `.github/workflows/auto_pirc_upgrade.yml`, insert:

```yaml
permissions:
  contents: write
```

between the `name: PiRC Auto-Upgrade & Build` and the `on:` block (or equivalently just after `on:` but before `jobs:`). No additional imports or methods are required because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
