### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -1,5 +1,8 @@
 name: PiRC-101 Full Production Pipeline (Safe Mode)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ze0ro99/PiRC/security/code-scanning/2](https://github.com/Ze0ro99/PiRC/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that limits the `GITHUB_TOKEN` to the least privileges required. This workflow only needs to read repository contents (for `actions/checkout` and caching keyed by repository files), so `contents: read` is sufficient. We can set this at the workflow root level so it applies to all jobs unless overridden.

The best minimal fix without changing existing functionality is to insert a `permissions:` section near the top of `.github/workflows/ci-full-pipeline.yml`, alongside `name:` and `on:`. Specifically, after line 2 (the blank line following the `name:`), add:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed; this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
