### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled command line

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,39 @@
 from fastapi import FastAPI
 import subprocess
 import json
+import re
 
 app = FastAPI()
 
 CONTRACT_ID = "ISI_DENGAN_CONTRACT_ID_KAMU"
+
+# Allow only a restricted set of characters in command-line arguments that come from the user.
+# This prevents passing values containing whitespace, control characters, or shell-like metacharacters.
+_SAFE_ARG_PATTERN = re.compile(r"^[A-Za-z0-9_\-:+=/]+$")
+
+
+def _validate_verify_input(data: dict) -> dict:
+    """
+    Validate and sanitize input for the /verify endpoint before it is passed
+    as arguments to the external 'soroban' process.
+    """
+    required_fields = ("pid", "issuer_pubkey", "signature", "chip_uid")
+    validated: dict = {}
+
+    for field in required_fields:
+        if field not in data:
+            raise ValueError(f"Missing required field: {field}")
+        value = str(data[field])
+        # Basic length limits to avoid abuse and overly long command-line arguments.
+        if not (1 <= len(value) <= 256):
+            raise ValueError(f"Invalid length for field: {field}")
+        # Enforce a conservative allow-list of characters.
+        if not _SAFE_ARG_PATTERN.match(value):
+            raise ValueError(f"Invalid characters in field: {field}")
+        validated[field] = value
+
+    return validated
+
 
 @app.get("/")
 def root():
@@ -13,6 +42,8 @@ def root():
 @app.post("/verify")
 def verify(data: dict):
     try:
+        validated = _validate_verify_input(data)
+
         cmd = [
             "soroban", "contract", "invoke",
             "--id", CONTRACT_ID,
@@ -20,10 +51,10 @@ def verify(data: dict):
             "--source", "alice",
             "--",
             "verify",
-            "--pid", data["pid"],
-            "--issuer_pubkey", data["issuer_pubkey"],
-            "--signature", data["signature"],
-            "--chip_uid", data["chip_uid"]
+            "--pid", validated["pid"],
+            "--issuer_pubkey", validated["issuer_pubkey"],
+            "--signature", validated["signature"],
+            "--chip_uid", validated["chip_uid"]
         ]
 
         result = subprocess.check_output(cmd).decode()


### PR DESCRIPTION
Potential fix for [https://github.com/Ze0ro99/PiRC/security/code-scanning/8](https://github.com/Ze0ro99/PiRC/security/code-scanning/8)

General approach: continue to invoke `soroban` using a hard‑coded command and the safe list‑style `subprocess` API, but validate and constrain all user‑provided fields before including them as argv elements. For this endpoint, simple but effective safeguards include: (1) enforcing that all required fields are present, (2) enforcing basic format/character allow‑lists for each field (e.g., only hex/base58/URL‑safe characters, no whitespace or control characters), and (3) limiting maximum lengths to prevent abuse. If validation fails, return a 400‑style error instead of calling `subprocess`.

Best concrete fix in this snippet: introduce a small internal validation helper in `api/main.py` that checks the four user inputs, then call it from within `verify` before building `cmd`. The helper should only allow characters typically expected in Stellar pubkeys, signatures, etc. (e.g., alphanumerics plus a small set like `_` or `-`) and enforce sane length caps. We don’t change the behavior for valid inputs, we only reject clearly malformed or suspicious values so functionality remains intact for normal callers.

Changes to make in `api/main.py`:

- Add an `import re` at the top (we already import `subprocess` and `json`; we won’t remove or alter those).
- Define a private function, e.g. `_validate_verify_input(data: dict) -> dict`, above `@app.post("/verify")`. This function:
  - Ensures `pid`, `issuer_pubkey`, `signature`, and `chip_uid` exist in `data`.
  - Applies a regular expression allow‑list per field (or a shared safe pattern) to disallow whitespace/control characters and suspicious punctuation.
  - Enforces max length per field (e.g., 128–256 chars, depending on field).
  - Returns a cleaned/normalized dict with only those validated fields, or raises a `ValueError` with a clear message if anything is invalid.
- In `verify`, call `_validate_verify_input(data)` at the start of the `try` block, assign to `validated` (or similar), and build `cmd` using `validated[...]` instead of raw `data[...]`.
- Optionally, adjust the `except` to distinguish `ValueError` from generic exceptions, but this is not strictly required; we can keep a single `except` and just surface its message.

No external packages beyond the standard library are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
