### PR TITLE
Potential fix for code scanning alert no. 307: Uncontrolled command line

### DIFF
--- a/PiRC/PiRC/PiRC/PiRC/api/main.py
+++ b/PiRC/PiRC/PiRC/PiRC/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 import subprocess
 import json
+import re
 
 app = FastAPI()
 
@@ -13,6 +14,25 @@ def root():
 @app.post("/verify")
 def verify(data: dict):
     try:
+        required_fields = ["pid", "issuer_pubkey", "signature", "chip_uid"]
+        for field in required_fields:
+            if field not in data or not isinstance(data[field], str):
+                return {"error": f"Invalid or missing field: {field}"}
+
+        pid = data["pid"].strip()
+        issuer_pubkey = data["issuer_pubkey"].strip()
+        signature = data["signature"].strip()
+        chip_uid = data["chip_uid"].strip()
+
+        if not re.fullmatch(r"[A-Za-z0-9._:-]{1,64}", pid):
+            return {"error": "Invalid pid format"}
+        if not re.fullmatch(r"[A-Za-z0-9+/=:_-]{16,256}", issuer_pubkey):
+            return {"error": "Invalid issuer_pubkey format"}
+        if not re.fullmatch(r"[A-Za-z0-9+/=:_-]{16,512}", signature):
+            return {"error": "Invalid signature format"}
+        if not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", chip_uid):
+            return {"error": "Invalid chip_uid format"}
+
         cmd = [
             "soroban", "contract", "invoke",
             "--id", CONTRACT_ID,
@@ -20,10 +40,10 @@ def verify(data: dict):
             "--source", "alice",
             "--",
             "verify",
-            "--pid", data["pid"],
-            "--issuer_pubkey", data["issuer_pubkey"],
-            "--signature", data["signature"],
-            "--chip_uid", data["chip_uid"]
+            "--pid", pid,
+            "--issuer_pubkey", issuer_pubkey,
+            "--signature", signature,
+            "--chip_uid", chip_uid
         ]
 
         result = subprocess.check_output(cmd).decode()


### PR DESCRIPTION
Potential fix for [https://github.com/Ze0ro99/PiRC/security/code-scanning/307](https://github.com/Ze0ro99/PiRC/security/code-scanning/307)

To fix this safely without changing intended functionality, validate and sanitize all user-provided fields before building `cmd`, and reject malformed inputs. The best approach is to enforce strict allowlist-style validation (length + character set / format) per field, then only pass validated values to `subprocess.check_output`.

In `PiRC/PiRC/PiRC/PiRC/api/main.py`, update `verify` to:
- Ensure required keys exist.
- Validate each input against strict regex rules (or explicit format checks).
- Return a 400-style error payload for invalid input instead of invoking the command.
- Build `cmd` using only validated values.

Also add `import re` for input validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
